### PR TITLE
Inline logging job logic and register intervals in place

### DIFF
--- a/ESP32-FlightControler/src/logging.cpp
+++ b/ESP32-FlightControler/src/logging.cpp
@@ -1,9 +1,98 @@
 #include "logging.h"
 #include "globals.h"
 #include <Arduino.h>
+#include <FS.h>
+#include <LittleFS.h>
 
 namespace {
-  bool logging_enabled = false;
+  constexpr size_t HISTORY_CAP = 64;        // ~12 seconds at 5 Hz
+  constexpr size_t PERSIST_QUEUE_CAP = 32;  // ~6 seconds at 5 Hz
+  const char* const LOG_FILE_PATH = "/global_history.csv";
+
+  struct LogEntry {
+    uint32_t timestamp_ms;
+    uint32_t counter1;
+    uint32_t counter2;
+  };
+
+  // RAM history ring buffer (keeps most recent HISTORY_CAP samples)
+  LogEntry history_buffer[HISTORY_CAP];
+  size_t   history_head = 0;  // Next position to write
+  size_t   history_size = 0;  // Number of valid entries in buffer
+
+  // Pending entries waiting to be persisted
+  LogEntry persist_queue[PERSIST_QUEUE_CAP];
+  size_t   persist_size = 0;
+
+  bool     logging_enabled = false;
+  bool     dump_requested = false;
+  bool     fs_ready = false;
+
+  void ensure_filesystem() {
+    if (!fs_ready) {
+      fs_ready = LittleFS.begin(true);
+      if (!fs_ready) {
+        Serial.println(F("[logging] Failed to mount LittleFS"));
+      }
+    }
+  }
+
+  void flush_pending_to_fs();
+
+  void capture_globals_job() {
+    const LogEntry entry{millis(), g_counter1, g_counter2};
+
+    history_buffer[history_head] = entry;
+    history_head = (history_head + 1) % HISTORY_CAP;
+    if (history_size < HISTORY_CAP) {
+      history_size++;
+    }
+
+    if (persist_size >= PERSIST_QUEUE_CAP) {
+      Serial.println(F("[logging] Persist queue full, forcing flush"));
+      flush_pending_to_fs();
+    }
+
+    if (persist_size >= PERSIST_QUEUE_CAP) {
+      Serial.println(F("[logging] Dropping oldest pending entry"));
+      for (size_t i = 1; i < persist_size; ++i) {
+        persist_queue[i - 1] = persist_queue[i];
+      }
+      persist_size = PERSIST_QUEUE_CAP - 1;
+    }
+
+    persist_queue[persist_size++] = entry;
+  }
+
+  void write_header_if_empty(File& f) {
+    if (f.size() == 0) {
+      f.println(F("timestamp_ms,counter1,counter2"));
+    }
+  }
+
+  void flush_pending_to_fs() {
+    if (persist_size == 0) return;
+    ensure_filesystem();
+    if (!fs_ready) return;
+
+    File f = LittleFS.open(LOG_FILE_PATH, FILE_APPEND);
+    if (!f) {
+      Serial.println(F("[logging] Failed to open history file"));
+      return;
+    }
+
+    write_header_if_empty(f);
+
+    for (size_t i = 0; i < persist_size; ++i) {
+      const LogEntry& e = persist_queue[i];
+      f.printf("%lu,%lu,%lu\n",
+               static_cast<unsigned long>(e.timestamp_ms),
+               static_cast<unsigned long>(e.counter1),
+               static_cast<unsigned long>(e.counter2));
+    }
+    f.close();
+    persist_size = 0;
+  }
 
   static void tpValue(const char *name, double value) {
     Serial.print('>');
@@ -13,12 +102,6 @@ namespace {
   }
 
   bool cond_logging_enabled() {
-    while (Serial.available() > 0) {
-      const int ch = Serial.read();
-      if (ch == 't' || ch == 'T') {
-        logging_enabled = !logging_enabled;
-      }
-    }
     return logging_enabled;
   }
 
@@ -26,9 +109,81 @@ namespace {
     tpValue("tp:g_counter1", g_counter1);
     tpValue("tp:g_counter2", g_counter2);
   }
+
+  bool cond_persist_needed() {
+    return persist_size > 0;
+  }
+
+  void dump_persistent_history() {
+    ensure_filesystem();
+    if (!fs_ready) {
+      Serial.println(F("[logging] LittleFS unavailable"));
+      return;
+    }
+
+    if (!LittleFS.exists(LOG_FILE_PATH)) {
+      Serial.println(F("[logging] No persisted history yet"));
+      return;
+    }
+
+    File f = LittleFS.open(LOG_FILE_PATH, FILE_READ);
+    if (!f) {
+      Serial.println(F("[logging] Failed to read history file"));
+      return;
+    }
+
+    Serial.println(F("[logging] --- Persisted history ---"));
+    while (f.available()) {
+      Serial.write(f.read());
+    }
+    f.close();
+  }
+
+  void dump_ram_history() {
+    Serial.println(F("[logging] --- Recent RAM history ---"));
+    if (history_size == 0) {
+      Serial.println(F("[logging] (empty)"));
+      return;
+    }
+
+    const size_t start = (history_head + HISTORY_CAP - history_size) % HISTORY_CAP;
+    for (size_t i = 0; i < history_size; ++i) {
+      const size_t idx = (start + i) % HISTORY_CAP;
+      const LogEntry& e = history_buffer[idx];
+      Serial.printf("%lu,%lu,%lu\n",
+                    static_cast<unsigned long>(e.timestamp_ms),
+                    static_cast<unsigned long>(e.counter1),
+                    static_cast<unsigned long>(e.counter2));
+    }
+  }
+
+  bool cond_dump_requested() {
+    while (Serial.available() > 0) {
+      const int ch = Serial.read();
+      if (ch == 't' || ch == 'T') {
+        logging_enabled = !logging_enabled;
+        Serial.print(F("[logging] Teleplot logging "));
+        Serial.println(logging_enabled ? F("enabled") : F("disabled"));
+      } else if (ch == 'l' || ch == 'L') {
+        dump_requested = true;
+      }
+    }
+
+    return dump_requested;
+  }
+
+  void job_dump_history() {
+    dump_requested = false;
+    flush_pending_to_fs();
+    dump_persistent_history();
+    dump_ram_history();
+    Serial.println(F("[logging] --- End of history ---"));
+  }
 }
 
 void register_logging(JobRegistry& R) {
+  ensure_filesystem();
+
   Job log_job = {
     "logging_teleplot_globals",
     JOB_TIMER,
@@ -40,4 +195,40 @@ void register_logging(JobRegistry& R) {
     /*fn=*/job_teleplot_globals
   };
   R.add(log_job);
+
+  Job capture_job = {
+    "logging_capture_globals",
+    JOB_TIMER,
+    /*interval_ms=*/200,
+    /*last_run_ms=*/0,
+    /*enabled=*/true,
+    /*ready=*/false,
+    /*condition=*/nullptr,
+    /*fn=*/capture_globals_job
+  };
+  R.add(capture_job);
+
+  Job persist_job = {
+    "logging_persist_history",
+    JOB_TIMER,
+    /*interval_ms=*/5000,
+    /*last_run_ms=*/0,
+    /*enabled=*/true,
+    /*ready=*/false,
+    /*condition=*/cond_persist_needed,
+    /*fn=*/flush_pending_to_fs
+  };
+  R.add(persist_job);
+
+  Job dump_job = {
+    "logging_dump_history",
+    JOB_EVENT,
+    /*interval_ms=*/0,
+    /*last_run_ms=*/0,
+    /*enabled=*/true,
+    /*ready=*/false,
+    /*condition=*/cond_dump_requested,
+    /*fn=*/job_dump_history
+  };
+  R.add(dump_job);
 }


### PR DESCRIPTION
## Summary
- inline the capture job logic so the ring buffer and persistence queue work is performed directly by the scheduled task
- use the flush routine directly for the persistence job and set the timer intervals at registration time instead of via constants

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc0a5e70cc832d825f475f9564e87f